### PR TITLE
Fix var to be array api compatible by using float64 for __truediv__

### DIFF
--- a/transformcl.py
+++ b/transformcl.py
@@ -138,7 +138,7 @@ def var(cl):
 
     """
     xp = array_namespace(cl)
-    ell = xp.arange(cl.shape[-1])
+    ell = xp.arange(cl.shape[-1], dtype=xp.float64)
     return xp.sum((2 * ell + 1) / (4 * xp.pi) * cl, axis=-1)
 
 

--- a/transformcl.py
+++ b/transformcl.py
@@ -138,6 +138,8 @@ def var(cl):
 
     """
     xp = array_namespace(cl)
+    # ell cannot be an integer here as, within the array api
+    # only floating-point dtypes are allowed in __truediv__
     ell = xp.arange(cl.shape[-1], dtype=xp.float64)
     return xp.sum((2 * ell + 1) / (4 * xp.pi) * cl, axis=-1)
 


### PR DESCRIPTION
This is a fix for the [issue pointed out in this PR](https://github.com/glass-dev/glass/pull/979#issuecomment-3816584549) on [glass-dev/glass](https://github.com/glass-dev/glass)